### PR TITLE
point main to dist/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "web3-providers-connex",
 	"version": "0.7.4",
 	"description": "Web3.js provider built upon Connex.js to allow Web3.js/ethers.js to be compatible with the Thor protocol",
-	"main": "dist/index.ts",
+	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist"


### PR DESCRIPTION
Artifacts in `dist` do not contain `index.ts`; `index.js` should be used instead so that the package can be installed in other projects.