### PR TITLE
Add default baseFeePerGas value

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -350,6 +350,7 @@ export class Formatter {
 			nonce: zeroBytes8,
 			logsBloom: zeroBytes256,
 			extraData: '0x',
+			baseFeePerGas: '0x0',
 		};
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export interface RetBlock extends RetHeader {
 	difficulty: '0x0';
 	totalDifficulty: '0x0';
 	uncles: [];
+	baseFeePerGas: '0x0';
 }
 export interface RetHeader {
 	number: string; 			// number in hex string


### PR DESCRIPTION
This PR is required for trampoline when using `web3-providers-connex` as the provider. Currently the default value for `baseFeePerGas` is `0x` in trampoline which fails when converting it to `BigNumber`. 