### PR TITLE
Return HexString ChainId instead of bignum

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -563,7 +563,8 @@ export class Provider extends EventEmitter implements IProvider {
 
 	private _getChainId = async (_: any[]) => {
 		const bigIntValue = BigInt(this.chainId);
-		return bigIntValue;
+		const bigIntValueAsHexString = "0x" + bigIntValue.toString(16);
+		return bigIntValueAsHexString;
 	}
 
 	private _getBlockByNumber = async (params: any[]) => {

--- a/test/web3/getChainId.test.ts
+++ b/test/web3/getChainId.test.ts
@@ -26,7 +26,7 @@ describe('Testing function getChainId', function () {
 			});
 
 			let res = await this.web3.eth.getChainId();
-			expect("0x" + res.toString(16)).to.eql(tag);
+			expect(res).to.eql(tag);
 		} catch (err: any) {
 			assert.fail(`Unexpected error: ${err}`);
 		}


### PR DESCRIPTION
This change is required because Remix Proxy fails in decoding the chainId when returned as a bignum.